### PR TITLE
ハイフン付きユーザー名のSecret名生成を修正

### DIFF
--- a/get-user-secret-key/action.yml
+++ b/get-user-secret-key/action.yml
@@ -31,8 +31,9 @@ runs:
           USERNAME="${{ github.actor }}"
         fi
 
-        # ユーザー名を大文字に変換
-        UPPER_USERNAME="${USERNAME^^}"
+        # ユーザー名を大文字に変換し、ハイフンをアンダースコアに置換
+        # GitHub Secretsではハイフンが使えないため変換が必要
+        UPPER_USERNAME=$(echo "${USERNAME^^}" | tr '-' '_')
         echo "username=$USERNAME" >> $GITHUB_OUTPUT
         echo "Processing user: $USERNAME -> $UPPER_USERNAME"
 


### PR DESCRIPTION
- ユーザー名のハイフンをアンダースコアに変換
- GitHub Secretsの命名規則に準拠
- 例: tanaka-yoshi10 → TANAKA_YOSHI10_CLAUDE_CODE_OAUTH_TOKEN